### PR TITLE
Added `--fallback-commit` option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ all:
 VERSION = $(shell src/git-version-gen.sh)
 
 TESTS = \
+    testOptionFallbackCommit \
     testOptionFallback
 
 test: $(TESTS)
@@ -49,4 +50,19 @@ testOptionFallback: src/git-version-gen.sh
 	  && test x'0.1.0' = x"`../$^ -- --fallback=0.1.0-test`" \
 	  && { cd .. && rm -r $@; } \
 	  || { cd .. && rm -r $@ && exit 1; }
+	@echo ' ok'
+
+.PHONY: testOptionFallbackCommit
+testOptionFallbackCommit: src/git-version-gen.sh
+	@echo -n $@...
+	@mkdir $@ \
+	  && cd $@ \
+	  && git init -q \
+	  && git commit -q --allow-empty -m"Initial commit" \
+	  && git commit -q --allow-empty -m"2nd commit" \
+	  && hash=`git rev-list -1 HEAD -- | cut -c -7` \
+	  && test x"0.1.0-1.g$${hash}" = x"`../$^ --fallback-commit=$${hash}^`" \
+	  && test x"0.1.0" = x"`../$^ --fallback-commit=$${hash}`" \
+	  && { cd .. && rm -rf $@; } \
+	  || { cd .. && rm -rf $@ && exit 1; }
 	@echo ' ok'

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Features
 * If an environment variable `VERSION` exists, then take it, formatted and returned.
 * If there is no git tag in the commit history, then return `0.1.0` or `VERSION`
   or `--fallback` value or use the value on the file `version`.
+* If there is no git tag in the commit history, then use the `--fallback-commit` option
+  to specify a base commit hash.
 
 Acknowledgments
 ---------------

--- a/src/git-version-gen.sh
+++ b/src/git-version-gen.sh
@@ -60,6 +60,12 @@ do
         --fallback=*)
             VERSION="${value}"
             ;; #(
+        --fallback-commit)
+            prevVarName='fallbackCommit'
+            ;; #(
+        --fallback-commit=*)
+            fallbackCommit="${value}"
+            ;; #(
         *)
             ;;
     esac
@@ -94,6 +100,17 @@ then
     VN=`sed -e 's,-\([1-9][0-9]*-g[0-9a-z]\{7\}\(-dirty\)\?\)$,.\\1,' <<EOF
 $VN
 EOF`
+elif test -d .git || test -f .git &&
+    test x != x"$fallbackCommit" &&
+    rev=`git log --pretty=%h "${fallbackCommit}.." | grep -c .` &&
+    case ${rev} in #(
+        0) VN=v${VERSION} ;; #(
+        *) VN=v${VERSION}-`expr ${rev}`.g`git log --pretty=%h HEAD -1` ;;
+    esac
+then
+    git update-index -q --refresh
+    test x = x"`git diff-index --name-only HEAD --`" ||
+    VN="${VN}-dirty"
 else
     VN="${VERSION}"
 fi


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Tests pass?     | yes
| Related tickets | ~
| License         | GNU GPL-v3+

When the commit history does not have any commit but you want to take a version from a base commit with the number of commit and the commit hash.

```sh
$ git log --pretty=%h -2
91536c2
76f4601

$ git-version-gen.sh --fallback-commit=76f4601
0.1.0-1.g91536c2
```